### PR TITLE
fix error where last view is undefined

### DIFF
--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -403,7 +403,7 @@ class ContinuousViewManager extends DefaultViewManager {
 
 		let append = () => {
 			let last = this.views.last();
-			if (last.section.idref.includes(EMPTY_PAGE_STRING) && !this.ignoreAutoProgress) {
+			if (last?.section && last.section.idref.includes(EMPTY_PAGE_STRING) && !this.ignoreAutoProgress) {
 				return Promise.resolve();
 			}
 


### PR DESCRIPTION
This fixes this issue:

![Screenshot 2023-12-13 at 9 44 53 AM](https://github.com/threadablebooks/epub.js/assets/881981/04d5137d-df2a-4fde-b48b-1c633da33e21)

The error was if you resized when on the first section of an epub, it would tell you that `last` was undefined and throw an error