### PR TITLE
check scroll of container parent if window hasnt scrolled

### DIFF
--- a/src/managers/continuous/index.js
+++ b/src/managers/continuous/index.js
@@ -390,7 +390,7 @@ class ContinuousViewManager extends DefaultViewManager {
 		let prepend = () => {
 			let first = this.views.first();
 
-			if (first?.section && first.section.idref.includes(EMPTY_PAGE_STRING) && !this.ignoreAutoProgress) {
+			if (first && first.section && first.section.idref.includes(EMPTY_PAGE_STRING) && !this.ignoreAutoProgress) {
 				return Promise.resolve();
 			}
 
@@ -403,7 +403,7 @@ class ContinuousViewManager extends DefaultViewManager {
 
 		let append = () => {
 			let last = this.views.last();
-			if (last?.section && last.section.idref.includes(EMPTY_PAGE_STRING) && !this.ignoreAutoProgress) {
+			if (last && last.section && last.section.idref.includes(EMPTY_PAGE_STRING) && !this.ignoreAutoProgress) {
 				return Promise.resolve();
 			}
 

--- a/src/managers/default/index.js
+++ b/src/managers/default/index.js
@@ -680,7 +680,11 @@ class DefaultViewManager {
 		let used = 0;
 
 		if(this.settings.fullsize) {
-			offset = vertical ? window.scrollY : window.scrollX;
+			if (!vertical) {
+				offset = window.scrollX;
+			} else {
+				offset = window.scrollY > 0 ? window.scrollY : this.container.parentElement.scrollTop || 0;
+			}
 		}
 
 		let sections = visible.map((view) => {


### PR DESCRIPTION
## What's in this PR?

The percentages for our epubs weren't working because it checks to see how far the user has scrolled down on the `window`. This PR checks to see if window scroll is 0, and if so, it grabs the scroll position of the container's parent.

## How to test?

Update your `package.json` to point `epubjs` to this branch
Do a fresh yarn install.
Load an epub and scroll through it
Does the percentage update correctly?