### PR TITLE
[Bug] Fix TOC creation for RN runtime

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -176,7 +176,7 @@ class Navigation {
 		if (!childList || childList.length === 0) return result;
 
 		// Filter for only element nodes (specifically 'li' elements)
-	    const items = Array.from(childList)
+		const items = Array.from(childList)
 			.filter(node => node.nodeType === 1 && node.nodeName.toLowerCase() === 'li');
 		if (!items || items.length === 0) return result;
 

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -171,10 +171,17 @@ class Navigation {
 
 		if (!navListHtml) return result;
 		if (!navListHtml.children) return result;
-		
-		for (let i = 0; i < navListHtml.children.length; i++) {
-			const item = this.navItem(navListHtml.children[i], parent);
 
+		const childList = navListHtml.children || navListHtml.childNodes;
+		if (!childList || childList.length === 0) return result;
+
+		// Filter for only element nodes (specifically 'li' elements)
+	    const items = Array.from(childList)
+			.filter(node => node.nodeType === 1 && node.nodeName.toLowerCase() === 'li');
+		if (!items || items.length === 0) return result;
+
+		for (let i = 0; i < items.length; i++) {
+			const item = this.navItem(items[i], parent);
 			if (item) {
 				result.push(item);
 			}


### PR DESCRIPTION
## Description

This fixes a bug where the TOC wasn't able to be created when running in a React Native runtime, primarily due to the use of `children` (which doesn't exist when running in RN). In addition to using `childNodes` instead of `children`, we also need to ensure the child nodes are `li` elements based on the [EPUB 3.0 spec](https://www.w3.org/TR/epub/#sec-nav-def-model).

Testing Code

```js
const epubBook = ePub(book64, { openAs: 'base64' });
const nav = await epubBook.loaded.navigation;

console.log(nav);
```

| Before | After | 
| --- | --- |
| ![image](https://github.com/user-attachments/assets/1aa085ee-b814-43c9-b987-d168f0e89e5b) | ![image](https://github.com/user-attachments/assets/4bc1481e-5016-4ebd-8dbd-78e215d4ea20) |